### PR TITLE
fix(container-shell): send EOT control character on close of container-shell

### DIFF
--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -313,6 +313,7 @@ export default {
 
     cleanup() {
       if (this.socket) {
+        this.socket.send(`0${ base64Encode('\x04') }`); // send ctrl+d(EOT) https://en.wikipedia.org/wiki/Control_character
         this.socket.disconnect();
         this.socket = null;
       }


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
fix(container-shell): send EOT control character on close of container-shell