### PR TITLE
fix(cluster): Iframe page pops up after add cluster cancellation

### DIFF
--- a/shell/components/EmberPage.vue
+++ b/shell/components/EmberPage.vue
@@ -438,6 +438,10 @@ export default {
         this.iframeEl.remove();
         this.initFrame();
         this.$store.dispatch('auth/logout');
+      } else if ( msg.action === 'need-redirect-to-cluster-index') {
+        this.iframeEl.remove();
+        this.initFrame();
+        this.$router.replace(this.fillRoute(INTERCEPTS['authenticated.cluster.index']));
       }
     },
 


### PR DESCRIPTION
2.7.0 功能迁移
- 修复创建集群取消后，并不会跳出 iframe 页面