### PR TITLE
fix(cluster import): Missing cluster-level image registry

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -287,7 +287,10 @@ export default {
       delete this.chartValues?.global?.systemDefaultRegistry;
       delete this.chartValues?.global?.cattle?.systemDefaultRegistry;
 
-      this.customRegistrySetting = existingRegistry || this.defaultRegistrySetting;
+      const isImported = this.currentCluster?.providerForEmberParam === 'import';
+      const clusterDefaultRegistry = isImported ? this.currentCluster?.spec?.systemDefaultRegistry : '';
+
+      this.customRegistrySetting = clusterDefaultRegistry || existingRegistry || this.defaultRegistrySetting;
       this.showCustomRegistryInput = !!this.customRegistrySetting;
 
       /* Serializes an object as a YAML document */


### PR DESCRIPTION
2.7.0功能迁移
- 配置集群层级的defult image registry时，部分组件遗失该配置。