### PR TITLE
fix(OPA Warning): Warning message by response header warning

### DIFF
--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -462,12 +462,20 @@ export default {
 
   load(ctx, { data, existing }) {
     const { getters, commit } = ctx;
-    const headWarnings = data?._headers?.['x-api-warnings'];
+    const headWarnings = data?._headers?.['warning'];
+    const warnings = headWarnings ? headWarnings.split('299') : [];
+    const messages = [];
 
-    if (headWarnings) {
+    warnings.forEach((warning) => {
+      if (warning && !warning.includes('violate PodSecurity') && !warning.includes('- unknown field')) {
+        messages.push(warning.substr(2));
+      }
+    });
+
+    if (messages.length) {
       ctx.dispatch('growl/warning', {
         title:   `${ capitalize(data?.type) }: ${ data?.metadata.name }`,
-        message: headWarnings,
+        message: decodeURIComponent(messages.join().replace(/\+/g, '%20')),
         timeout: 0,
       }, { root: true });
     }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fixes https://github.com/cnrancher/pandaria/issues/2731
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

上游已经合并了steve warning header修改，废弃掉RPM GC相同的修改功能使用上游修改方案。前端也将更改为使用上游修改方案。
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

OPA Gatekeeper 提示信息 由 Response Headers 的 “x-api-warnings” 更改为 “warning” 获取。
目前获取到的信息有以下几类

1. 空字符串
2. unknown field
3. violate PodSecurity
4. OPA Gatekeeper

前端将过滤掉1，2，3，将4信息作为提示内容显示出来。
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
#### 先决条件

1. 创建 OPA Gatekeeper

**ConstraintTemplate**
```
apiVersion: templates.gatekeeper.sh/v1
kind: ConstraintTemplate
metadata:
  name: k8spspprivilegedcontainer
  annotations:
    description: >-
      Controls the ability of any container to enable privileged mode.
      Corresponds to the `privileged` field in a PodSecurityPolicy. For more
      information, see
      https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged
spec:
  crd:
    spec:
      names:
        kind: K8sPSPPrivilegedContainer
      validation:
        openAPIV3Schema:
          type: object
          description: >-
            Controls the ability of any container to enable privileged mode.
            Corresponds to the `privileged` field in a PodSecurityPolicy. For more
            information, see
            https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged
          properties:
            exemptImages:
              description: >-
                Any container that uses an image that matches an entry in this list will be excluded
                from enforcement. Prefix-matching can be signified with `*`. For example: `my-image-*`.
                It is recommended that users use the fully-qualified Docker image name (e.g. start with a domain name)
                in order to avoid unexpectedly exempting images from an untrusted repository.
              type: array
              items:
                type: string
  targets:
    - target: admission.k8s.gatekeeper.sh
      rego: |
        package k8spspprivileged
        import data.lib.exempt_container.is_exempt
        violation[{"msg": msg, "details": {}}] {
            c := input_containers[_]
            not is_exempt(c)
            c.securityContext.privileged
            msg := sprintf("提示：Privileged container is not allowed: %v, securityContext: %v", [c.name, c.securityContext])
        }
        input_containers[c] {
            c := input.review.object.spec.containers[_]
        }
        input_containers[c] {
            c := input.review.object.spec.initContainers[_]
        }
        input_containers[c] {
            c := input.review.object.spec.ephemeralContainers[_]
        }
      libs:
        - |
          package lib.exempt_container
          is_exempt(container) {
              exempt_images := object.get(object.get(input, "parameters", {}), "exemptImages", [])
              img := container.image
              exemption := exempt_images[_]
              _matches_exemption(img, exemption)
          }
          _matches_exemption(img, exemption) {
              not endswith(exemption, "*")
              exemption == img
          }
          _matches_exemption(img, exemption) {
              endswith(exemption, "*")
              prefix := trim_suffix(exemption, "*")
              startswith(img, prefix)
          }
```
** K8sPSPPrivilegedContainer**
```
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: K8sPSPPrivilegedContainer
metadata:
  name: psp-privileged-container
spec:
  enforcementAction: warn
  match:
    kinds:
      - apiGroups: [""]
        kinds: ["Pod"]
    excludedNamespaces: ["cattle-prometheus","cattle-gatekeeper-system","cis-operator-system","cattle-fleet-system","cattle-gatekeeper-system","cattle-impersonation-system","cattle-logging-system","cattle-monitoring-system","kube-system","cattle-system"]
```

2. 设置 namespace **pod 安全准入**

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/57650029/225581263-60439094-2b51-4562-adfc-026f3a2d5321.png">


case1:
创建pod yaml 如下：

```
apiVersion: v1
kind: Pod
metadata:
  name: privileged
  namespace: default
spec:
  containers:
    - name: pause
      image: nginx
      securityContext:
        privileged: true
```
结果：显示 OPA Gatekeeper 提示信息内容
case2:
创建pod：

1. name: test, image: nginx, 安全性上下文: 允许权限提升: 是，安全性上下文: Privileged: 是

结果：分别显示 OPA Gatekeeper 提示信息，和**PodSecurity 违规**提示信息


case3:
创建pod

1. name: test, image: nginx, 安全性上下文: 允许权限提升: 是，安全性上下文: Privileged: 否

结果：只显示**PodSecurity 违规**提示信息

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
https://github.com/cnrancher/dashboard/pull/434
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
