### PR TITLE
test(cluster registry): Name the registry secret with the domain name

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/RegistryConfigs.test.js
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/RegistryConfigs.test.js
@@ -1,0 +1,31 @@
+import RegistryConfigs from '@shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue';
+
+describe('component: RegistryConfigs, methods: generateName', () => {
+  const defaultGenerateName = 'registryconfig-auth-';
+
+  it('should return default generate name when empty hostname & empty registry hostname', () => {
+    const row = [];
+    const localThis = { registryHost: '' };
+
+    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(defaultGenerateName);
+  });
+
+  it('should return row hostname1 generate name', () => {
+    const row = { value: { hostname: 'a.a.a' } };
+    const localThis = { registryHost: '' };
+
+    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(`${ row.value.hostname }-`);
+  });
+  it('should return row hostname2 generate name', () => {
+    const row = { value: { hostname: 'a.a.a' } };
+    const localThis = { registryHost: 'b.b.b' };
+
+    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(`${ row.value.hostname }-`);
+  });
+  it('should return registry hostname generate name', () => {
+    const row = { value: { hostName: '' } };
+    const localThis = { registryHost: 'b.b.b' };
+
+    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(`${ localThis.registryHost }-`);
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.js
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.js
@@ -1,0 +1,17 @@
+import rke2 from '@shell/edit/provisioning.cattle.io.cluster/rke2.vue';
+
+describe('component: rke2, computed: generateName', () => {
+  const defaultGenerateName = 'registryconfig-auth-';
+
+  it('should return default generate name when empty registry hostname', () => {
+    const localThis = { registryHost: '' };
+
+    expect(rke2.computed.generateName.call(localThis)).toBe(defaultGenerateName);
+  });
+
+  it('should return registry hostname generate name', () => {
+    const localThis = { registryHost: 'a.a.a' };
+
+    expect(rke2.computed.generateName.call(localThis)).toBe(`${ localThis.registryHost }-`);
+  });
+});


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fixes https://github.com/cnrancher/pandaria/issues/2417
 
## Problem

在创建集群添加过镜像仓库凭证之后会自动保存，但是保存的名称不太直观，无法辨认对应的是哪一个仓库域名。所以建议此处镜像仓库凭证名称以域名名称来命名。
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
根据当前用户输入的仓库主机名去增加别名前缀，方便识别。
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
配置高级容器 Mirror 和仓库验证选项：
case1: 
填写“仓库验证的Registry Hostname”，创建 HTTP 基本身份验证密文，并添加用户名和密码，创建rke2集群，凭证名称按Registry Hostname作为前缀名称显示。rke2集群可以部署成功
case2: 
填写“仓库验证的Registry Hostname”，填写“用于 SUSE Rancher 镜像的仓库主机名”，创建 HTTP 基本身份验证密文，并添加用户名和密码，创建rke2集群，凭证名称按Registry Hostname作为前缀名称显示。rke2集群可以部署成功
case3: 
不填写“仓库验证的Registry Hostname”，填写“用于 SUSE Rancher 镜像的仓库主机名”，创建 HTTP 基本身份验证密文，并添加用户名和密码，创建rke2集群，凭证名称按“用于 SUSE Rancher 镜像的仓库主机名”作为前缀名称显示。rke2集群可以部署成功
case4: 
不填写“仓库验证的Registry Hostname”，不填写“用于 SUSE Rancher 镜像的仓库主机名”，创建 HTTP 基本身份验证密文，并添加用户名和密码，创建rke2集群，凭证名称按默认值“registryconfig-auth-”作为前缀名称显示。rke2集群可以部署成功

从私有仓库中为 SUSE Rancher 拉取镜像
case1: 
填写“用于 SUSE Rancher 镜像的仓库主机名”，创建 HTTP 基本身份验证密文，并添加用户名和密码，创建rke2集群，凭证名称按“用于 SUSE Rancher 镜像的仓库主机名”作为前缀名称显示。rke2集群可以部署成功
case2:
不填写“用于 SUSE Rancher 镜像的仓库主机名”，创建 HTTP 基本身份验证密文，并添加用户名和密码，创建rke2集群，凭证名称按默认值“registryconfig-auth-”作为前缀名称显示。rke2集群可以部署成功
### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

UI 添加单元测试，判断当用户填写“仓库验证的 Registry Hostname” 和 “用于 SUSE Rancher 镜像的仓库主机名” 创建 HTTP 基本身份验证密文时，是否按照主机名内容作为凭证名称的前缀

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
