### PR TITLE
fix(alert): Upadate alert V2

### DIFF
--- a/shell/assets/translations-cn/en-us.yaml
+++ b/shell/assets/translations-cn/en-us.yaml
@@ -3197,7 +3197,6 @@ monitoringReceiver:
     add:
       aliyunSMS: Aliyun SMS
       dingTalk: Ding Talk
-      msTeams: MS Teams
       serviceNow: Service Now
     aliyunSMS:
       accessKeyIdLabel: Access Key
@@ -3211,7 +3210,7 @@ monitoringReceiver:
       signatureNamePlaceholder: e.g. mysign
       templateCodeLabel: Template Code
       templateCodePlaceholder: e.g. mytemplate
-    banner: To use Ding Talk, AliCloud SMS or MS Teams you will need to have <pre class="inline-block m-0 p-0 vertical-middle">pandaria-alerting-drivers</pre> installed first.
+    banner: To use Ding Talk or AliCloud SMS you will need to have <pre class="inline-block m-0 p-0 vertical-middle">pandaria-alerting-drivers</pre> installed first.
     dingTalk:
       secretLabel: Secret
       secretPlaceholder: Only for webhook with sign enabled

--- a/shell/assets/translations-cn/zh-hans.yaml
+++ b/shell/assets/translations-cn/zh-hans.yaml
@@ -3189,7 +3189,6 @@ monitoringReceiver:
     add:
       aliyunSMS: 阿里云短信
       dingTalk: 钉钉
-      msTeams: MS Teams
       serviceNow: Service Now
     aliyunSMS:
       accessKeyIdLabel: 访问秘钥
@@ -3203,7 +3202,7 @@ monitoringReceiver:
       signatureNamePlaceholder: 签名管理中配置的签名名称
       templateCodeLabel: 模版 CODE
       templateCodePlaceholder: 模版管理中配置的模版对应的 CODE
-    banner: 要使用Ding Talk、阿里云短信或MS Teams，你需要先安装<pre class="inline-block m-0 p-0 vertical-middle">pandaria-alerting-drivers</pre>。
+    banner: 要使用Ding Talk 或阿里云短信，你需要先安装 <pre class="inline-block m-0 p-0 vertical-middle">pandaria-alerting-drivers</pre> 实例。
     dingTalk:
       secretLabel: 密钥
       secretPlaceholder: 仅在选择“加签”时需要填写

--- a/shell/assets/translations-cn/zh-hant-tw.yaml
+++ b/shell/assets/translations-cn/zh-hant-tw.yaml
@@ -3189,7 +3189,6 @@ monitoringReceiver:
     add:
       aliyunSMS: 阿里雲短信
       dingTalk: 釘釘
-      msTeams: MS Teams
       serviceNow: Service Now
     aliyunSMS:
       accessKeyIdLabel: 訪問秘鑰
@@ -3203,7 +3202,7 @@ monitoringReceiver:
       signatureNamePlaceholder: 簽名管理中配置的簽名名稱
       templateCodeLabel: 模版 CODE
       templateCodePlaceholder: 模版管理中配置的模版對應的 CODE
-    banner: 要使用Ding Talk、阿里雲短信或MS Teams，你需要先安裝<pre class="inline-block m-0 p-0 vertical-middle">pandaria-alerting-drivers</pre>。
+    banner: 要使用 Ding Talk 或阿里雲短信，你需要先安裝 <pre class="inline-block m-0 p-0 vertical-middle">pandaria-alerting-drivers</pre> 实例。
     dingTalk:
       secretLabel: 密鑰
       secretPlaceholder: 僅在選擇“加簽”時需要填寫

--- a/shell/assets/translations-cn/zh-hant.yaml
+++ b/shell/assets/translations-cn/zh-hant.yaml
@@ -3189,7 +3189,6 @@ monitoringReceiver:
     add:
       aliyunSMS: 阿里雲短信
       dingTalk: 釘釘
-      msTeams: MS Teams
       serviceNow: Service Now
     aliyunSMS:
       accessKeyIdLabel: 訪問祕鑰
@@ -3203,7 +3202,7 @@ monitoringReceiver:
       signatureNamePlaceholder: 簽名管理中配置的簽名名稱
       templateCodeLabel: 模版 CODE
       templateCodePlaceholder: 模版管理中配置的模版對應的 CODE
-    banner: 要使用Ding Talk、阿里雲短信或MS Teams，你需要先安裝<pre class="inline-block m-0 p-0 vertical-middle">pandaria-alerting-drivers</pre>。
+    banner: 要使用 Ding Talk 或阿里雲短信，你需要先安裝 <pre class="inline-block m-0 p-0 vertical-middle">pandaria-alerting-drivers</pre> 实例。
     dingTalk:
       secretLabel: 密鑰
       secretPlaceholder: 僅在選擇“加簽”時需要填寫

--- a/shell/components/formatter/ReceiverIcons.vue
+++ b/shell/components/formatter/ReceiverIcons.vue
@@ -1,6 +1,8 @@
 <script>
 import { RECEIVERS_TYPES } from '@shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue';
 import { MONITORING } from '@shell/config/types';
+import { PANDARIA_WEBHOOK_URL } from '@shell/edit/monitoring.coreos.com.alertmanagerconfig/types/pandariaWebhook.vue';
+
 export default {
   props:      {
     value: {
@@ -48,6 +50,22 @@ export default {
   methods: {
     // get count and logo for each type configured in a given receiver
     getReceiverTypes(receiver) {
+      receiver = JSON.parse(JSON.stringify(receiver));
+      if (receiver.webhookConfigs && receiver.webhookConfigs.length) {
+        const webhookConfigs = [];
+        const pandariaWebhookConfigs = receiver.pandariaWebhookConfigs || [];
+
+        receiver.webhookConfigs.forEach((i) => {
+          if (i?.url.startsWith(PANDARIA_WEBHOOK_URL)) {
+            pandariaWebhookConfigs.push(i);
+          } else {
+            webhookConfigs.push(i);
+          }
+        });
+
+        receiver.webhookConfigs = webhookConfigs;
+        receiver.pandariaWebhookConfigs = pandariaWebhookConfigs;
+      }
       // iterate through predefined types and sum the number configured in this receiver
       const types = RECEIVERS_TYPES
         .reduce((types, type) => {

--- a/shell/config/product/monitoring.js
+++ b/shell/config/product/monitoring.js
@@ -69,7 +69,9 @@ export function init(store) {
           slack_configs:     { type: `array[${ RECEIVER_SLACK }]` },
           pagerduty_configs: { type: `array[${ RECEIVER_PAGERDUTY }]` },
           opsgenie_configs:  { type: `array[${ RECEIVER_OPSGENIE }]` },
-          webhook_configs:   { type: `array[${ RECEIVER_WEBHOOK }]` }
+          webhook_configs:   { type: `array[${ RECEIVER_WEBHOOK }]` },
+
+          pandaria_webhook_configs: { type: `array[${ RECEIVER_WEBHOOK }]` }
         }
       },
       {

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -52,6 +52,14 @@ export default {
     const routeSchema = this.$store.getters['cluster/schemaFor'](MONITORING.SPOOFED.ALERTMANAGERCONFIG_ROUTE_SPEC);
     const receiverOptions = (this.value?.spec?.receivers || []).map(receiver => receiver.name);
 
+    receiverSchema.resourceFields.pandariaWebhookConfigs = {
+      type:        'array[monitoring.coreos.com.v1alpha1.alertmanagerconfig.spec.receivers.webhookConfigs]',
+      nullable:    true,
+      create:      true,
+      update:      true,
+      description: 'List of pandaria webhook configurations.'
+    };
+
     return {
       actionMenuTargetElement:  null,
       actionMenuTargetEvent:    null,

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -50,6 +50,15 @@ export const RECEIVERS_TYPES = [
     title:        'monitoringReceiver.webhook.title',
     key:          'webhookConfigs',
     logo:         require(`@shell/assets/images/vendor/webhook.svg`),
+
+    pandariaLabel: 'monitoringReceiver.pandariaWebhook.label',
+  },
+  {
+    name:         'pandariaWebhook',
+    label:        'monitoringReceiver.pandariaWebhook.label',
+    title:        'monitoringReceiver.pandariaWebhook.title',
+    key:          'pandariaWebhookConfigs',
+    logo:         require(`@shell/assets/images/vendor/webhook.svg`),
   },
   {
     name:  'custom',
@@ -122,6 +131,14 @@ export default {
      * }
      */
     const receiverSchema = this.$store.getters[`${ inStore }/schemaFor`](MONITORING.SPOOFED.ALERTMANAGERCONFIG_RECEIVER_SPEC);
+
+    receiverSchema.resourceFields.pandariaWebhookConfigs = {
+      type:        'array[monitoring.coreos.com.v1alpha1.alertmanagerconfig.spec.receivers.webhookConfigs]',
+      nullable:    true,
+      create:      true,
+      update:      true,
+      description: 'List of pandaria webhook configurations.'
+    };
 
     // debugger;
 
@@ -249,10 +266,10 @@ export default {
     :resource="alertmanagerConfigResource"
     :subtypes="[]"
     :can-yaml="true"
-    :errors="errors"
+    :errors="alertmanagerConfigResource.errors"
     :cancel-event="true"
     @error="e=>errors = e"
-    @finish="saveOverride()"
+    @finish="saveOverride"
     @cancel="redirectAfterCancel"
   >
     <div class="row mb-10">

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/aliyunSms.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/aliyunSms.vue
@@ -1,0 +1,99 @@
+<script>
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { Checkbox } from '@components/Form/Checkbox';
+import InputListPandaria from '@shell/components/form/InputListPandaria';
+
+export default {
+  components: {
+    Checkbox, LabeledInput, InputListPandaria
+  },
+  props:      {
+    mode: {
+      type:     String,
+      required: true,
+    },
+    value: {
+      type:     Object,
+      required: true
+    }
+  },
+
+  data() {
+    const phone = this.value.http_config.phone ? this.value.http_config.phone : [];
+
+    return { phone };
+  },
+
+  watch: {
+    phone(newVal) {
+      if (this.value) {
+        this.value.http_config.phone = newVal;
+      }
+    }
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.http_config.access_key_id"
+          type="password"
+          :mode="mode"
+          :required="true"
+          :label="t('monitoringReceiver.pandariaWebhook.aliyunSMS.accessKeyIdLabel')"
+          :placeholder="t('monitoringReceiver.pandariaWebhook.aliyunSMS.accessKeyIdPlaceholder')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.http_config.access_key_secret"
+          type="password"
+          :required="true"
+          :mode="mode"
+          :label="t('monitoringReceiver.pandariaWebhook.aliyunSMS.accessKeySecretLabel')"
+          :placeholder="t('monitoringReceiver.pandariaWebhook.aliyunSMS.accessKeySecretPlaceholder')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.http_config.template_code"
+          :required="true"
+          :mode="mode"
+          :label="t('monitoringReceiver.pandariaWebhook.aliyunSMS.templateCodeLabel')"
+          :placeholder="t('monitoringReceiver.pandariaWebhook.aliyunSMS.templateCodePlaceholder')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.http_config.sign_name"
+          :required="true"
+          :mode="mode"
+          :label="t('monitoringReceiver.pandariaWebhook.aliyunSMS.signatureNameLabel')"
+          :placeholder="t('monitoringReceiver.pandariaWebhook.aliyunSMS.signatureNamePlaceholder')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-12">
+        <InputListPandaria
+          :input-list="phone"
+          :mode="mode"
+          :input-label="t('monitoringReceiver.pandariaWebhook.aliyunSMS.phoneNumberLabel')"
+          :placeholder="t('monitoringReceiver.pandariaWebhook.aliyunSMS.phoneNumberPlaceholder')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <Checkbox
+        v-model="value.sendResolved"
+        :mode="mode"
+        :label="t('monitoringReceiver.shared.sendResolved.label')"
+      />
+    </div>
+  </div>
+</template>

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/dingTalk.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/dingTalk.vue
@@ -1,0 +1,51 @@
+<script>
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { Checkbox } from '@components/Form/Checkbox';
+
+export default {
+  components: { Checkbox, LabeledInput },
+  props:      {
+    mode: {
+      type:     String,
+      required: true,
+    },
+    value: {
+      type:     Object,
+      required: true
+    }
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-12">
+        <LabeledInput
+          v-model="value.http_config.proxy_url"
+          :mode="mode"
+          :label="t('monitoringReceiver.shared.proxyUrl.label')"
+          :placeholder="t('monitoringReceiver.shared.proxyUrl.placeholder')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-12">
+        <LabeledInput
+          v-model="value.http_config.secret"
+          type="password"
+          :mode="mode"
+          :label="t('monitoringReceiver.pandariaWebhook.dingTalk.secretLabel')"
+          :placeholder="t('monitoringReceiver.pandariaWebhook.dingTalk.secretPlaceholder')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <Checkbox
+        v-model="value.sendResolved"
+        :mode="mode"
+        :label="t('monitoringReceiver.shared.sendResolved.label')"
+      />
+    </div>
+  </div>
+</template>

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/pandariaWebhook.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/pandariaWebhook.vue
@@ -1,0 +1,122 @@
+<script>
+import { LabeledInput } from '@components/Form/LabeledInput';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { Banner } from '@components/Banner';
+import { _VIEW } from '@shell/config/query-params';
+import { ALIBABA_CLOUD_SMS_URL, MS_TEAMS_URL } from '@shell/edit/monitoring.coreos.com.receiver/types/webhook.add.vue';
+import DingTalk from './dingTalk';
+import AliyunSms from './aliyunSms';
+
+export const WEBHOOK_TYPES = {
+  DING_TALK:   'DINGTALK',
+  ALIYUN_SMS: 'ALIYUN_SMS',
+};
+
+export const PANDARIA_WEBHOOK_URL = 'http://alerting-drivers.cattle-monitoring-system.svc:9094/';
+
+export default {
+  components: {
+    Banner, LabeledInput, DingTalk, AliyunSms, LabeledSelect
+  },
+  props:      {
+    mode: {
+      type:     String,
+      required: true,
+    },
+    value: {
+      type:     Object,
+      required: true
+    }
+  },
+  data() {
+    this.$set(this.value, 'http_config', this.value.http_config || {});
+    this.$set(this.value, 'send_resolved', this.value.send_resolved || false);
+    const isDriverUrl = this.value.url === MS_TEAMS_URL || this.value.url === ALIBABA_CLOUD_SMS_URL;
+
+    return {
+      showNamespaceBanner: isDriverUrl && this.mode !== _VIEW,
+      view:                 _VIEW,
+      webhookOptons:        [
+        {
+          label: this.t('monitoringReceiver.pandariaWebhook.add.dingTalk'),
+          value: WEBHOOK_TYPES.DING_TALK
+        },
+        {
+          label: this.t('monitoringReceiver.pandariaWebhook.add.aliyunSMS'),
+          value: WEBHOOK_TYPES.ALIYUN_SMS
+        },
+      ],
+      selectedWebhookType: this.value.type || 'DINGTALK',
+    };
+  },
+
+  computed: {
+    showTargetUrl() {
+      return this.selectedWebhookType !== WEBHOOK_TYPES.ALIYUN_SMS;
+    }
+  },
+
+  methods: {
+    updateWebhookType(event) {
+      this.value.type = event;
+    },
+  }
+};
+</script>
+
+<template>
+  <div>
+    <Banner
+      v-if="mode !== view"
+      color="info"
+      v-html="t('monitoringReceiver.pandariaWebhook.banner', {}, raw=true)"
+    />
+    <div class="row mb-20">
+      <LabeledSelect
+        v-model="selectedWebhookType"
+        :disabled="mode === view"
+        :label="t('monitoringReceiver.webhook.add.selectWebhookType')"
+        :placeholder="t('monitoringReceiver.webhook.add.generic')"
+        :localized-label="true"
+        :options="webhookOptons"
+        @input="updateWebhookType($event)"
+      />
+    </div>
+    <div class="row">
+      <div class="col span-12">
+        <h3 class="mb-0">
+          Target
+        </h3>
+      </div>
+    </div>
+    <Banner
+      v-if="showNamespaceBanner"
+      color="info"
+      v-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)"
+    />
+    <div
+      v-if="showTargetUrl"
+      class="row mb-20"
+    >
+      <div class="col span-12">
+        <LabeledInput
+          v-model="value.webhook_url"
+          :required="true"
+          :mode="mode"
+          label="URL"
+          :tooltip="t('monitoringReceiver.webhook.urlTooltip')"
+        />
+      </div>
+    </div>
+    <AliyunSms
+      v-if="selectedWebhookType==='ALIYUN_SMS'"
+      :value="value"
+      :mode="mode"
+    />
+    <DingTalk
+      v-else
+      :value="value"
+      :mode="mode"
+    />
+  </div>
+</template>

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -110,16 +110,18 @@ export default {
     // Pandaria extra webhook
     Object.keys(this.value.spec).forEach((key) => {
       if (key === WEBHOOKKEY && this.value.spec[key]?.length > 0) {
-        const newData = [];
+        const webhookConfigs = [];
+        const pandariaWebhookConfigs = [];
 
         this.value.spec[key].forEach((item) => {
           if (item?.url?.startsWith(PANDARIAWEBHOOKURL)) {
-            suffix[PANDARIAWEBHOOKKEY]?.push(item);
+            pandariaWebhookConfigs.push(item);
           } else {
-            newData.push(item);
+            webhookConfigs.push(item);
           }
         });
-        this.value.spec[key] = newData;
+        this.value.spec[key] = webhookConfigs;
+        this.value.spec.pandaria_webhook_configs = pandariaWebhookConfigs;
       }
     });
 

--- a/shell/edit/monitoring.coreos.com.receiver/types/pandariaWebhook.add.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/pandariaWebhook.add.vue
@@ -23,10 +23,6 @@ export default {
           value: 'DINGTALK'
         },
         {
-          label: this.t('monitoringReceiver.pandariaWebhook.add.msTeams'),
-          value: 'MICROSOFT_TEAMS'
-        },
-        {
           label: this.t('monitoringReceiver.pandariaWebhook.add.aliyunSMS'),
           value: 'ALIYUN_SMS'
         },


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fixes https://github.com/cnrancher/pandaria/issues/2846
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

alerting v2 优化
1. 原先 route-receiver 部分即将废弃，移植 pandaria-alerting-driver 支持的 receiver 配置到 alertmanagerconfig。
2. 因 alerting-driver 已支持 MS teams，移除 pandaria-alerting-driver 支持的 receiver MS teams。
3. 移除 custom 配置时默认显示的 pandaria_webhook_configs 配置内容。

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

根据需求完成 alerting v2 优化
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
https://github.com/cnrancher/dashboard/pull/448
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
