### PR TITLE
fix(global monitorning): Fix custom token not taking effect

### DIFF
--- a/shell/assets/translations-cn/en-us.yaml
+++ b/shell/assets/translations-cn/en-us.yaml
@@ -7486,6 +7486,7 @@ globalMonitoringPage:
     custom:
       label: Custom token
       placeholder: Please configure a custom token
+      yamlRequired: The apiToken field must be configured
   customAddress:
     add: Add Address
     otherHeader: Customize other addresses

--- a/shell/assets/translations-cn/zh-hans.yaml
+++ b/shell/assets/translations-cn/zh-hans.yaml
@@ -7768,6 +7768,7 @@ globalMonitoringPage:
     custom:
       label: 自定义 token
       placeholder: 请配置自定义 token
+      yamlRequired: apiToken 字段必须配置
   customAddress:
     add: 添加地址
     otherHeader: 自定义其他地址

--- a/shell/assets/translations-cn/zh-hant-tw.yaml
+++ b/shell/assets/translations-cn/zh-hant-tw.yaml
@@ -7768,6 +7768,7 @@ globalMonitoringPage:
     custom:
       label: 自定義 token
       placeholder: 請配置自定義 token
+      yamlRequired: apiToken 字段必須配置
   customAddress:
     add: 添加地址
     otherHeader: 自定義其他地址

--- a/shell/assets/translations-cn/zh-hant.yaml
+++ b/shell/assets/translations-cn/zh-hant.yaml
@@ -7767,6 +7767,7 @@ globalMonitoringPage:
     custom:
       label: 自定義 token
       placeholder: 請配置自定義 token
+      yamlRequired: apiToken 字段必須配置
   customAddress:
     add: 添加地址
     otherHeader: 自定義其他地址

--- a/shell/components/ThanosCatalog/index.vue
+++ b/shell/components/ThanosCatalog/index.vue
@@ -195,7 +195,8 @@ export default {
         return item;
       }));
     },
-    updateApiToken() {
+    updateApiToken(val) {
+      this.$emit('updateUseDefaultToken', val);
       if (this.useDefaultToken) {
         this.$set(this.value.ui, 'apiToken', '');
       }

--- a/shell/pages/c/_cluster/manager/globalMonitoring/index.vue
+++ b/shell/pages/c/_cluster/manager/globalMonitoring/index.vue
@@ -126,6 +126,7 @@ export default {
         timeout:       600,
         historyMax:    5,
       },
+      useDefaultToken: true,
     };
   },
   watch: {
@@ -416,7 +417,10 @@ export default {
     },
     async save(btnCb) {
       this.validate();
-      this.$set(this, 'errors', this.value.errors || []);
+
+      const errors = this.errors.concat(this.value.errors || []);
+
+      this.$set(this, 'errors', errors);
       delete this.value.errors;
 
       try {
@@ -530,10 +534,12 @@ export default {
         const useDefaultToken = this.$refs.thanosCatalog.useDefaultToken;
 
         return useDefaultToken;
-      } else {
+      } else if (this.value?.ui?.apiToken) {
         const apiToken = this.value.ui.apiToken;
 
         return !apiToken;
+      } else {
+        return this.useDefaultToken;
       }
     },
 
@@ -737,6 +743,8 @@ export default {
     initApiToken() {
       const useDefaultToken = this.monitoringSettings?.useDefaultToken === 'true';
 
+      this.useDefaultToken = useDefaultToken;
+
       if (useDefaultToken) {
         this.$set(this.value.ui, 'apiToken', '');
       }
@@ -801,6 +809,13 @@ export default {
     },
 
     validate() {
+      this.errors = [];
+
+      if (!this.showValuesComponent) {
+        if (!this.useDefaultToken && !this.value.ui.apiToken) {
+          this.errors.push(this.t('globalMonitoringPage.token.custom.yamlRequired', true));
+        }
+      }
       if (this.$refs.thanosCatalog) {
         this.$refs.thanosCatalog.validate();
       }
@@ -809,6 +824,10 @@ export default {
     updateWarning: throttle(function() {
       this.getStoreWarnings();
     }, 1500, { trailing: true }),
+
+    updateUseDefaultToken(neu) {
+      this.useDefaultToken = neu;
+    },
 
     getStoreWarnings() {
       const warnings = [];
@@ -976,6 +995,7 @@ export default {
               :monitoring-settings="monitoringSettings"
               @updateVersion="updateVersion"
               @updateWarning="updateWarning"
+              @updateUseDefaultToken="updateUseDefaultToken"
             />
           </template>
           <template v-else>


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Fixes https://github.com/cnrancher/pandaria/issues/2911

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

通过 Yaml 创建全局监控，未正确判断用户是否使用默认token导致的

2.7 导致问题：

使用自定义 Token，并通过 Yaml 创建全局监控时，如果不填写 apiToken 字段依然可以创建成功
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

当用户使用自定义 Token，并通过 Yaml 创建全局监控时，增加 apiToken 字段必填校验。
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
1. 全局监控未启用，使用自定义token，且不填写自定义token，切换到 YAML编辑 页面，点击创建，页面提示 `apiToken 字段必须配置`
2. 使用默认token，切换到 YAML编辑 页面，点击创建，全局监控创建成功
3. 编辑 2 创建成功的全局监控，修改为使用自定义token，且不填写自定义token，切换到 YAML编辑 页面，点击创建，页面提示 `apiToken 字段必须配置`
4. 在3的基础上，在 YAML编辑页面，填写 apiToken 字段，点击创建，全局监控创建成功。

当用户选择使用自定义token，且不填写token内容，并使用yaml创建时，增加前端校验提示，拦截用户创建全局监控
### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
待补充
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

另外需要同时验证下2.6版本发现问题，是否在2.7版本存在。

1. 使用默认 token 创建全局监控
6. 创建成功后刷新页面，切换到 编辑YAML 页面
7. 点击保存，验证是否可以成功创建。（2.6问题是无法保存成功，接口会报错）

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->













## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fixes https://github.com/cnrancher/pandaria/issues/2911
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

通过yaml创建全局监控，未正确判断用户是否使用默认token导致的

导致问题：
1. 全局监控启用，使用默认token
2. 编辑，修改为不使用默认token, 但是什么都不填写
3. 切换到 yaml 页面，点击保存
8. 依然可以正常保存成功 （此时前端依然判断为是 使用默认token）
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

当用户选择使用自定义token，且不填写token内容，并使用yaml创建时，增加前端校验提示，拦截用户创建全局监控
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

当用户选择使用自定义token，且不填写token内容，并使用yaml创建时，增加前端校验提示，拦截用户创建全局监控
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
待补充
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

另外需要同时验证下2.6版本发现问题，是否在2.7版本存在，编辑时，选择使用默认token，并使用yaml创建。当不填写apiToken也可以创建成功。
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
