### PR TITLE
fix(macvlan): Fix macvlan extension

### DIFF
--- a/pkg/macvlan/l10n/zh-hans.yaml
+++ b/pkg/macvlan/l10n/zh-hans.yaml
@@ -50,7 +50,7 @@ macvlan:
   ipReuse:
     ipReuseFormatError: 自动 IP 延迟回收 格式错误
     ipReuseUnit: 分钟
-    label: 自动IP延迟回收
+    label: 自动 IP 延迟回收
     placeholder: 取值范围 1-3600 之间的整数
   master:
     label: Master

--- a/pkg/macvlan/l10n/zh-hant-tw.yaml
+++ b/pkg/macvlan/l10n/zh-hant-tw.yaml
@@ -50,7 +50,7 @@ macvlan:
   ipReuse:
     ipReuseFormatError: 自動 IP 延遲回收 格式錯誤
     ipReuseUnit: 分鐘
-    label: 自動IP延遲回收
+    label: 自動 IP 延遲回收
     placeholder: 取值範圍 1-3600 之間的整數
   master:
     label: Master

--- a/pkg/macvlan/l10n/zh-hant.yaml
+++ b/pkg/macvlan/l10n/zh-hant.yaml
@@ -50,7 +50,7 @@ macvlan:
   ipReuse:
     ipReuseFormatError: 自動 IP 延遲回收 格式錯誤
     ipReuseUnit: 分鐘
-    label: 自動IP延遲回收
+    label: 自動 IP 延遲回收
     placeholder: 取值範圍 1-3600 之間的整數
   master:
     label: Master

--- a/pkg/macvlan/routing/macvlan-routing.js
+++ b/pkg/macvlan/routing/macvlan-routing.js
@@ -10,7 +10,7 @@ const routes = [
   },
   {
     name:      `${ MACVLAN_IP_PRODUCT_NAME }-c-cluster-resource-ip`,
-    path:      `/:product/c/:cluster/:resource/ip/:id`,
+    path:      `/c/:cluster/:product/:resource/ip/:id`,
     component: MacvlanResourceIps,
   },
 ];


### PR DESCRIPTION
修复 macvlan Extension 问题
1. ip Delay Reuse 增加校验提示
2. 选取“项目”时，创建不成功
3. macvlanIP 页面访问报错

issue：issue： https://github.com/cnrancher/pandaria/issues/2972
