### PR TITLE
fix(snapshot): Fix backup failed prompt

### DIFF
--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -73,14 +73,21 @@ const etcdBackupPromptRke1 = (ctx, data) => {
 
   const t = ctx.rootGetters['i18n/t'];
   const currentCluster = ctx.rootGetters['management/byId'](MANAGEMENT.CLUSTER, data.clusterId);
-  const state = data.state === 'failed' ? 'fail' : 'success';
+  const state = data.state === 'failed' || data.state === 'error' ? 'fail' : 'success';
   const title = `${ t(`cluster.snapshot.${ state }.title`) }`;
   const message = t(`cluster.snapshot.${ state }.message`, { name: currentCluster.nameDisplay });
 
-  ctx.dispatch(`growl/${ state === 'fail' ? 'fromError' : 'success' }`, {
-    title,
-    message,
-  }, { root: true });
+  if (state === 'fail') {
+    ctx.dispatch('growl/fromError', {
+      title,
+      err: message,
+    }, { root: true });
+  } else {
+    ctx.dispatch('growl/success', {
+      title,
+      message,
+    }, { root: true });
+  }
 };
 
 const etcdBackupPromptRke2 = (ctx, data) => {
@@ -871,7 +878,7 @@ const defaultActions = {
       }
     }
 
-    if ( type === 'etcdBackup' && (data.state === 'failed' || data.state === 'active')) {
+    if ( type === 'etcdBackup' && (data.state === 'failed' || data.state === 'error' || data.state === 'active')) {
       etcdBackupPromptRke1(ctx, data);
     }
   },


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fixes https://github.com/cnrancher/pandaria/issues/2618
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

rke1 集群快照备份失败没有提示
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

失败后WS推送的状态值是error，当状态值为 error 时，增加备份失败的提示。
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
待补充
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
