### PR TITLE
fix(macvlan): Fix macvlan Extension

### DIFF
--- a/pkg/macvlan/dialog/promptRemoveMacvlanDialog.vue
+++ b/pkg/macvlan/dialog/promptRemoveMacvlanDialog.vue
@@ -94,28 +94,11 @@ export default {
         };
       });
     },
-    displayMacvlanIp(anno) {
-      const networkStatusStr = anno?.['k8s.v1.cni.cncf.io/networks-status'];
+    displayMacvlanIp(labels = {}) {
+      const type = labels['macvlan.panda.io/macvlanIpType'];
+      const ip = labels['macvlan.pandaria.cattle.io/selectedIp'];
 
-      if (!networkStatusStr) {
-        return '';
-      }
-      let networkStatus;
-
-      try {
-        networkStatus = JSON.parse(networkStatusStr);
-      } catch (err) {
-        return '';
-      }
-      if (networkStatus) {
-        const macvlan = networkStatus.find(n => n.interface === 'eth1');
-        const labels = this.labels;
-        const type = labels && labels['macvlan.panda.io/macvlanIpType'];
-
-        return `${ (macvlan && macvlan.ips && macvlan.ips[0]) || '' }${ type ? ` (${ type })` : '' }`;
-      }
-
-      return '';
+      return `${ ip || '' }${ type ? ` (${ type })` : '' }`;
     },
     async getPods(name) {
       let pods = await this.$store.dispatch('macvlan/loadMacvlanPods', {
@@ -129,12 +112,12 @@ export default {
       let more = false;
       let morePods = [];
 
-      pods = Array.from(pods).filter(({ metadata }) => metadata && metadata.annotations && this.displayMacvlanIp(metadata.annotations)
+      pods = Array.from(pods).filter(({ metadata }) => metadata && metadata.annotations && this.displayMacvlanIp(metadata.labels)
       ).map(({ metadata }) => {
         return {
           namespace: metadata.namespace,
           podName:   metadata.name,
-          ip:        this.displayMacvlanIp(metadata.annotations)
+          ip:        this.displayMacvlanIp(metadata.labels)
         };
       });
 

--- a/pkg/macvlan/edit/macvlan.cluster.cattle.io.macvlansubnet.vue
+++ b/pkg/macvlan/edit/macvlan.cluster.cattle.io.macvlansubnet.vue
@@ -29,6 +29,7 @@ export default {
     CruResource,
   },
   data() {
+    const isClone = this.$route?.query?.mode === 'clone';
     let config = JSON.parse(JSON.stringify(this.$store.getters['macvlan/emptyForm']));
 
     if (this.value.spec) {
@@ -42,7 +43,7 @@ export default {
       };
     }
 
-    if (!config.spec.ranges) {
+    if (!config.spec.ranges || isClone) {
       config.spec.ranges = [];
     }
     if (!config.spec.routes) {
@@ -117,22 +118,6 @@ export default {
       });
 
       return out;
-    },
-    mastheadData() {
-      const {
-        creationTimestamp, parentNameOverride, parentLocationOverride, detailPageHeaderActionOverride
-      } = this;
-
-      return {
-        ...this.config,
-        creationTimestamp,
-        parentNameOverride,
-        parentLocationOverride,
-        detailPageHeaderActionOverride
-      };
-    },
-    creationTimestamp() {
-      return this.config?.metadata?.creationTimestamp;
     },
     fvExtraRules() {
       const ipv4RegExp = /^(((\d{1,2})|(1\d{2})|(2[0-4]\d)|(25[0-5]))\.){3}((\d{1,2})|(1\d{2})|(2[0-4]\d)|(25[0-5]))$/;
@@ -272,7 +257,7 @@ export default {
         ranges, master, vlan, cidr
       } = this.config.spec;
 
-      if ((!ranges || ranges.length === 0) && this.hasDuplicateCidr(cidr)) {
+      if (this.isCreate && (!ranges || ranges.length === 0) && this.hasDuplicateCidr(cidr)) {
         errors.push(this.t('macvlan.ipRange.formInfoExist', {
           master,
           vlan,

--- a/pkg/macvlan/list/macvlan.cluster.cattle.io.macvlansubnet.vue
+++ b/pkg/macvlan/list/macvlan.cluster.cattle.io.macvlansubnet.vue
@@ -5,11 +5,10 @@ import ResourceTable from '@shell/components/ResourceTable';
 import { ROWS_PER_PAGE } from '@shell/store/prefs';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import { MACVLAN_PRODUCT_NAME, MACVLAN_CHARTS } from '../config/macvlan-types';
-import InstallView from '../components/InstallView.vue';
 
 export default {
   name:       'ListMacvlan',
-  components: { ResourceTable, InstallView },
+  components: { ResourceTable },
   mixins:     [ResourceFetch],
   props:      {
     schema: {
@@ -120,20 +119,15 @@ export default {
 </script>
 <template>
   <div>
-    <InstallView
-      v-if="!existing"
+    <ResourceTable
+      v-bind="$attrs"
+      :headers="headers"
+      :rows="rows"
+      :groupable="false"
+      :schema="schema"
+      key-field="_key"
+      :loading="loading"
+      v-on="$listeners"
     />
-    <div v-else>
-      <ResourceTable
-        v-bind="$attrs"
-        :headers="headers"
-        :rows="rows"
-        :groupable="false"
-        :schema="schema"
-        key-field="_key"
-        :loading="loading"
-        v-on="$listeners"
-      />
-    </div>
   </div>
 </template>


### PR DESCRIPTION
修复 macvlan Extension 问题
1. 修复 安装页面刷新报错问题。 --移除list页面引入的 InstallView 页面
2. 修复 删除macvlansubnet，有macvlan的数据，没有展示macvlanip数据
3. 修复 vlan不为0，编辑subnet，保存报错
4. 修复 克隆时IP Range没有删除

issue： https://github.com/cnrancher/pandaria/issues/2972