### PR TITLE
fix(macvlan): Fix ipDelayReuse and name validation

### DIFF
--- a/pkg/macvlan/edit/macvlan.cluster.cattle.io.macvlansubnet.vue
+++ b/pkg/macvlan/edit/macvlan.cluster.cattle.io.macvlansubnet.vue
@@ -76,7 +76,7 @@ export default {
           path: 'spec.gateway', rules: ['gatewayVlidate'], rootObject: config
         },
         {
-          path: 'spec.ipDelayReuse', rules: ['ipDelayReuseVlidate'], rootObject: config
+          path: 'ipDelayReuse', rules: ['ipDelayReuseVlidate'], rootObject: this
         },
         {
           path: 'spec.ranges', rules: ['ipRangeVlidate'], rootObject: config
@@ -126,7 +126,11 @@ export default {
       const nameChar = (value) => {
         const errors = [];
 
-        validateKubernetesName(value, this.t('macvlan.name.label'), this.$store.getters, { minLength: 0 }, errors);
+        if (value.length < 2) {
+          errors.push(this.t('macvlan.name.tooShort', { key: this.t('macvlan.name.label'), min: 2 }));
+        } else {
+          validateKubernetesName(value, this.t('macvlan.name.label'), this.$store.getters, { minLength: 2 }, errors);
+        }
 
         if (errors.length) {
           return errors[0];
@@ -158,7 +162,10 @@ export default {
         }
       };
       const ipDelayReuseVlidate = (value) => {
-        if (value < 1 || value > 3600 || (value > 1 && value % 1 !== 0)) {
+        if (!value) {
+          return;
+        }
+        if (value < 1 || value > 3600 || value % 1 !== 0) {
           return this.t('macvlan.ipReuse.placeholder');
         }
       };
@@ -239,6 +246,10 @@ export default {
 
     ipDelayReuse: {
       get() {
+        if (!this.config.spec.ipDelayReuse) {
+          return '';
+        }
+
         return this.config.spec.ipDelayReuse / 60;
       },
       set(neu) {
@@ -485,7 +496,7 @@ export default {
                 type="number"
                 min="1"
                 max="3600"
-                :rules="fvGetAndReportPathRules('spec.ipDelayReuse')"
+                :rules="fvGetAndReportPathRules('ipDelayReuse')"
               />
             </div>
           </div>

--- a/pkg/macvlan/l10n/en-us.yaml
+++ b/pkg/macvlan/l10n/en-us.yaml
@@ -63,6 +63,7 @@ macvlan:
     nameFormatError: "name consists of alphanumeric and ._-, not more than 62 characters in length and beginning with a letter or number"
     nameReq: "name cannot be empty"
     placeholder: e.g. testvlan
+    tooShort: '"{key}" cannot be shorter than {min} characters'
   project:
     label: Project
   route:

--- a/pkg/macvlan/l10n/zh-hans.yaml
+++ b/pkg/macvlan/l10n/zh-hans.yaml
@@ -63,6 +63,7 @@ macvlan:
     nameFormatError: 项目名称由字母、数字、和._-组成，长度不超过 62 且至少有两个字符并以字母或数字开头
     nameReq: 名称不能为空
     placeholder: 例如：testvlan
+    tooShort: '"{key}" 的长度不能小于{min}个字符'
   project:
     label: 项目
   route:

--- a/pkg/macvlan/l10n/zh-hant-tw.yaml
+++ b/pkg/macvlan/l10n/zh-hant-tw.yaml
@@ -63,6 +63,7 @@ macvlan:
     nameFormatError: 項目名稱由字母、數字、和._-組成，長度不超過 62 且至少有兩個字符並以字母或數字開頭
     nameReq: 名稱不能為空
     placeholder: 例如：testvlan
+    tooShort: '"{key}" 的長度不能小於{min}個字符'
   project:
     label: 項目
   route:

--- a/pkg/macvlan/l10n/zh-hant.yaml
+++ b/pkg/macvlan/l10n/zh-hant.yaml
@@ -63,6 +63,7 @@ macvlan:
     nameFormatError: 項目名稱由字母、數字、和._-組成，長度不超過 62 且至少有兩個字符並以字母或數字開頭
     nameReq: 名稱不能為空
     placeholder: 例如：testvlan
+    tooShort: '"{key}" 的長度不能小於{min}個字符'
   project:
     label: 項目
   route:


### PR DESCRIPTION
修复 macvlan Extension 问题
1. 修复 自动 IP 延迟回收 和  名称 检验错误

issue： https://github.com/cnrancher/pandaria/issues/2972