### PR TITLE
fix(globalmonitorning): Fix errors when deployment cluster is unavail…

### DIFF
--- a/shell/pages/c/_cluster/manager/globalMonitoring/index.vue
+++ b/shell/pages/c/_cluster/manager/globalMonitoring/index.vue
@@ -634,7 +634,7 @@ export default {
 
       const settings = {
         ...DEFAULT_GMV2_SETTING,
-        clusterId: this.currentCluster.id,
+        clusterId: this.currentCluster?.id || 'local',
         enabled:   'false'
       };
 


### PR DESCRIPTION
修复部署全局监控的集群不可用时，进入到全局监控页面，页面报错问题。

https://github.com/cnrancher/pandaria/issues/2925