### PR TITLE
fix(cluster registry): Fix create auth secret

### DIFF
--- a/shell/components/form/SelectOrCreateAuthSecret.vue
+++ b/shell/components/form/SelectOrCreateAuthSecret.vue
@@ -5,7 +5,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { AUTH_TYPE, NORMAN, SECRET } from '@shell/config/types';
 import { SECRET_TYPES } from '@shell/config/secret';
-import { base64Encode } from '@shell/utils/crypto';
+import { base64Decode, base64Encode } from '@shell/utils/crypto';
 import { addObjects, insertAt } from '@shell/utils/array';
 import { sortBy } from '@shell/utils/sort';
 
@@ -57,6 +57,11 @@ export default {
     generateName: {
       type:    String,
       default: 'auth-',
+    },
+
+    displayName: {
+      type:     String,
+      required: true,
     },
 
     allowNone: {
@@ -230,8 +235,10 @@ export default {
 
           return true;
         }).map((x) => {
+          const displayNameByHostName = base64Decode(x.metadata?.annotations?.['display-name'] || '');
+
           return {
-            label: `${ x.metadata.name } (${ x.subTypeDisplay }: ${ x.dataPreview })`,
+            label: `${ displayNameByHostName || x.metadata.name } (${ x.subTypeDisplay }: ${ x.dataPreview })`,
             group: x.metadata.namespace,
             value: x.id,
           };
@@ -414,7 +421,8 @@ export default {
           type:     SECRET,
           metadata: {
             namespace:    this.namespace,
-            generateName: this.generateName
+            generateName: this.generateName,
+            annotations:  { 'display-name': this.displayName }
           },
         });
 

--- a/shell/components/form/__tests__/SelectOrCreateAuthSecret.test.js
+++ b/shell/components/form/__tests__/SelectOrCreateAuthSecret.test.js
@@ -1,0 +1,25 @@
+import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret.vue';
+import { base64Encode } from '@shell/utils/crypto';
+
+describe('component: SelectOrCreateAuthSecret, computed: options', () => {
+  it('should return anno display-name options', () => {
+    const host = 'a.b.c:8080';
+    const item = {
+      id:        'id1',
+      namespace: 'test',
+      metadata:  { namespace: 'test', annotations: { 'display-name': base64Encode(host) } }
+    };
+    const localThis = {
+      t:          t => t,
+      allSecrets: [item]
+    };
+
+    const options = SelectOrCreateAuthSecret.computed.options.call(localThis);
+
+    expect(options[options.length - 1]).toStrictEqual({
+      label: `${ host } (${ item.subTypeDisplay }: ${ item.dataPreview })`,
+      group: item.metadata.namespace,
+      value: item.id,
+    });
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -7,6 +7,7 @@ import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthS
 import CreateEditView from '@shell/mixins/create-edit-view';
 import SecretSelector from '@shell/components/form/SecretSelector';
 import { SECRET_TYPES as TYPES } from '@shell/config/secret';
+import { base64Encode } from '@shell/utils/crypto';
 
 export default {
   components: {
@@ -81,6 +82,7 @@ export default {
   },
 
   methods: {
+    base64Encode,
     update() {
       const configs = {};
 
@@ -114,11 +116,11 @@ export default {
       const hostname = row?.value?.hostname;
 
       if (hostname) {
-        return `${ hostname }-`;
+        return `${ hostname }`;
       } else if (this.registryHost) {
-        return `${ this.registryHost }-`;
+        return `${ this.registryHost }`;
       } else {
-        return 'registryconfig-auth-';
+        return '';
       }
     },
   }
@@ -153,7 +155,8 @@ export default {
               :vertical="true"
               :namespace="value.metadata.namespace"
               :mode="mode"
-              :generate-name="generateName(row)"
+              generate-name="registryconfig-auth-"
+              :display-name="base64Encode(generateName(row))"
             />
           </div>
           <div class="col span-6">

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/RegistryConfigs.test.js
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/RegistryConfigs.test.js
@@ -1,31 +1,29 @@
 import RegistryConfigs from '@shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue';
 
 describe('component: RegistryConfigs, methods: generateName', () => {
-  const defaultGenerateName = 'registryconfig-auth-';
-
   it('should return default generate name when empty hostname & empty registry hostname', () => {
     const row = [];
     const localThis = { registryHost: '' };
 
-    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(defaultGenerateName);
+    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe('');
   });
 
   it('should return row hostname1 generate name', () => {
     const row = { value: { hostname: 'a.a.a' } };
     const localThis = { registryHost: '' };
 
-    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(`${ row.value.hostname }-`);
+    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(row.value.hostname);
   });
   it('should return row hostname2 generate name', () => {
     const row = { value: { hostname: 'a.a.a' } };
     const localThis = { registryHost: 'b.b.b' };
 
-    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(`${ row.value.hostname }-`);
+    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(row.value.hostname);
   });
   it('should return registry hostname generate name', () => {
     const row = { value: { hostName: '' } };
     const localThis = { registryHost: 'b.b.b' };
 
-    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(`${ localThis.registryHost }-`);
+    expect(RegistryConfigs.methods.generateName.call(localThis, row)).toBe(localThis.registryHost);
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.js
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.js
@@ -1,17 +1,15 @@
 import rke2 from '@shell/edit/provisioning.cattle.io.cluster/rke2.vue';
 
 describe('component: rke2, computed: generateName', () => {
-  const defaultGenerateName = 'registryconfig-auth-';
-
   it('should return default generate name when empty registry hostname', () => {
     const localThis = { registryHost: '' };
 
-    expect(rke2.computed.generateName.call(localThis)).toBe(defaultGenerateName);
+    expect(rke2.computed.generateName.call(localThis)).toBe('');
   });
 
   it('should return registry hostname generate name', () => {
     const localThis = { registryHost: 'a.a.a' };
 
-    expect(rke2.computed.generateName.call(localThis)).toBe(`${ localThis.registryHost }-`);
+    expect(rke2.computed.generateName.call(localThis)).toBe(localThis.registryHost);
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -885,11 +885,7 @@ export default {
     },
 
     generateName() {
-      if (this.registryHost) {
-        return `${ this.registryHost }-`;
-      } else {
-        return 'registryconfig-auth-';
-      }
+      return this.registryHost || '';
     },
   },
 
@@ -977,6 +973,7 @@ export default {
   },
 
   methods: {
+    base64Encode,
     nlToBr,
     set,
 
@@ -2135,7 +2132,8 @@ export default {
             :allow-rke="true"
             :vertical="true"
             :namespace="value.metadata.namespace"
-            :generate-name="generateName"
+            generate-name="registryconfig-auth-"
+            :display-name="base64Encode(generateName)"
           />
           <template v-else-if="registryMode === ADVANCED">
             <RegistryMirrors


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fixes https://github.com/cnrancher/pandaria/issues/2891
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

ui 创建 k3s/rke2 集群添加镜像仓库认证信息时, 主机名带端口会报主机名无效
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

前端修改方案如下：

1. 前端发送POST secret请求时保持generateName为registryconfig-auth-，与开源的命名规则保持一致
2. 构造 secret 结构体时，在 annotation 中增加 display-name 属性，将其设置为用户配置的 Registry Hostname，这里需要对 Registry Hostname 值 base64 编码后保存。
3. 在反显数据时，如果 annotation 中包含 display-name 属性，则名称显示 display-name 的 base64 decode 的值，如果无法 decode，则直接显示 display-name 值，如果不包含 display-name 属性则保持原有逻辑，显示secret name。
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
待补充
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
