### PR TITLE
fix(node): Memory usage changed to use Allocatable calculation

### DIFF
--- a/shell/detail/node.vue
+++ b/shell/detail/node.vue
@@ -120,7 +120,7 @@ export default {
       return null;
     },
     memoryUnits() {
-      const exponent = exponentNeeded(this.value.ramCapacity, 1024);
+      const exponent = exponentNeeded(this.value.ramAllocatable, 1024);
 
       return `${ UNITS[exponent] }iB`;
     },
@@ -241,7 +241,7 @@ export default {
       />
       <ConsumptionGauge
         :resource-name="t('node.detail.glance.consumptionGauge.memory')"
-        :capacity="value.ramCapacity"
+        :capacity="value.ramAllocatable"
         :used="value.ramUsage"
         :units="memoryUnits"
         :number-formatter="memoryFormatter"

--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -218,8 +218,12 @@ export default class ClusterNode extends SteveModel {
     return parseSi(this.status.capacity.memory);
   }
 
+  get ramAllocatable() {
+    return parseSi(this.status.allocatable?.memory);
+  }
+
   get ramUsagePercentage() {
-    return ((this.ramUsage * 100) / this.ramCapacity).toString();
+    return ((this.ramUsage * 100) / this.ramAllocatable).toString();
   }
 
   get podUsage() {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Fixes https://github.com/cnrancher/pandaria/issues/2865

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Cluster Explorer中展示的Node节点Memory Usage跟kubectl top node统计出的Usage存在差异
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Kubectl Top指令使用Allocatable而ClusterExplorer中使用的是Node Capacity.

UI 显示由 Node Capacity 更改为 Allocatable
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
待补充
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

