### PR TITLE
fix(macvlan): Fix route product parameters on the installation page

### DIFF
--- a/pkg/macvlan/macvlan-config.js
+++ b/pkg/macvlan/macvlan-config.js
@@ -16,7 +16,7 @@ export function init($plugin, store) {
     route:      {
       name:   `${ MACVLAN_PRODUCT_NAME }-c-cluster-resource-install`,
       params: {
-        product:  'explor',
+        product:  'explorer',
         resource: MACVLAN_PRODUCT_NAME
       }
     },


### PR DESCRIPTION
修改 Macvlan Extension 安装页面 路由 product 参数书写错误问题