### PR TITLE
fix(workload metrics): Fix grafana data display error

### DIFF
--- a/shell/models/apps.deployment.js
+++ b/shell/models/apps.deployment.js
@@ -12,12 +12,22 @@ const IGNORED_ANNOTATIONS = [
 
 export default class Deployment extends Workload {
   get replicaSetId() {
-    const set = this.metadata?.relationships?.find((relationship) => {
+    const set = this.metadata?.relationships?.filter((relationship) => {
       return relationship.rel === 'owner' &&
             relationship.toType === WORKLOAD_TYPES.REPLICA_SET;
     });
 
-    return set?.toId?.replace(`${ this.namespace }/`, '');
+    if (set?.length === 1) {
+      return set[0]?.toId?.replace(`${ this.namespace }/`, '');
+    }
+
+    if (this.pods.length) {
+      return this.pods?.[0]?.ownersByType?.ReplicaSet?.[0]?.name;
+    } else {
+      const condition = this.status?.conditions?.find(condition => condition.type === 'Progressing' && condition.message);
+
+      return condition ? condition.message?.match(/"(\S*)"/)[1] : set?.[0]?.toId?.replace(`${ this.namespace }/`, '');
+    }
   }
 
   async rollBack(cluster, deployment, revision) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
Fixes https://github.com/cnrancher/pandaria/issues/2508
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

当 deployment 有多个 replicaSet 时。 前端获取replicaSetId错误导致 metric 无法展示
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

1. 如果 deployment 的 relationships 只有一个符合标准的 replicaset，那么取该值。
2. 如果deployment的relationships 有多个replicaset：
     - 如果Pod数不为0，则从第一个 pod 中找到合适的replicaset；
     - 如果Pod数为0，则从 status.conditions 中 message 中截取 replicaSetId；
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
待补充
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
